### PR TITLE
Fix - Replace Coursera URL with Arizona interleaving strategy resource

### DIFF
--- a/app/[locale]/introduction/page.tsx
+++ b/app/[locale]/introduction/page.tsx
@@ -95,9 +95,9 @@ export default async function Introduction({
                   {t.rich("section2.description.paragraph3", {
                     link: (chunks) => (
                       <TrackedExternalLink
-                        href="https://www.coursera.org/learn/learning-how-to-learn"
+                        href="https://academicaffairs.arizona.edu/l2l-strategy-interleaving"
                         className="text-blue-600 hover:underline font-medium inline-flex items-center gap-1"
-                        resourceName="coursera"
+                        resourceName="interleaving_strategy"
                       >
                         {chunks}
                         <ExternalLink className="h-4 w-4" />

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -110,7 +110,7 @@ export const getResourceType = (url: string): string => {
   if (hostname.includes('youtube.com') || hostname.includes('youtu.be')) return 'youtube';
   if (hostname.includes('coursera.org')) return 'coursera';
   if (hostname.includes('the-joy-of-react') || hostname.includes('joyofreact')) return 'joy_of_react';
-  if (hostname.includes('academicaffairs.arizona.edu')) return 'interleaving_study';
+  if (hostname.includes('academicaffairs.arizona.edu')) return 'interleaving_strategy';
   
   return 'external';
 };


### PR DESCRIPTION
## Summary
- Replace Coursera learning resource URL with Arizona academic affairs interleaving strategy resource
- Update GA4 resource tracking from "coursera" to "interleaving_strategy" 
- Ensure analytics helper properly identifies the new Arizona domain

## Test plan
- [x] Verify new URL loads correctly in both English and Spanish locales
- [x] Test GA4 tracking fires with correct resource name "interleaving_strategy"
- [ ] Confirm analytics helper identifies Arizona domain properly

🤖 Generated with [Claude Code](https://claude.ai/code)